### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ build
 /vendor/
 /composer.lock
 bin/
+docs
 doc/temp
+.phpdoc
 .phpunit.result.cache

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test::
 	bin/phpunit
 
 docs::
-	bin/phpdoc -d classes -t docs -p
+	phpDocumentor.phar -d src -t docs
 
 doc::
 	$(MAKE) $(MFLAGS) -C doc

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Requirements
 ============
 
-To use PHPTAL in your projects, you will require PHP 7.2 or later.
+To use PHPTAL in your projects, you will require PHP 7.3 or later.
 
 If you want to use the builtin internationalisation system (I18N), the php-gettext extension must be installed or compiled into PHP (`--with-gettext`).
 
@@ -35,3 +35,6 @@ Addition development requirements (optional)
 If you would like to generate the offical html/text handbook by calling
 `make doc`, you will need to install the `xmlto` package. Please use
 your operating systems package manager to install it.
+
+If you'd like to create the sourcecode documentation, you need the `phpDocumentor.phar` executable
+in your `$PATH`.

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,7 @@
         "symfony/polyfill-mbstring": "^1.12"
     },
     "require-dev": {
-        "ext-dom": "*",
-        "ext-simplexml": "*",
-        "php": "^7.3",
         "phpunit/phpunit": "^9",
-        "phpdocumentor/phpdocumentor": "^2",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
Drop phpDocumentator as direct dependency as since 3.x, installation by
composer is not supported any longer