### PR TITLE
Ensure php8 compatibility

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        php: [7.3, 7.4]
+        os: ['ubuntu-latest']
+        php-versions: [7.3, 7.4, 8.0]
     steps:
       - name: Set locales
         run: |
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-versions }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -39,7 +39,6 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Monthly Downloads](https://poser.pugx.org/scn/phptal/d/monthly)](https://packagist.org/packages/scn/phptal)
 [![License](https://poser.pugx.org/scn/phptal/license)](LICENSE)
-[![Build Status](https://travis-ci.org/SC-Networks/PHPTAL.svg?branch=master)](https://travis-ci.org/SC-Networks/PHPTAL)
+[![unittest](https://github.com/SC-Networks/PHPTAL/actions/workflows/unittests.yml/badge.svg)](https://github.com/SC-Networks/PHPTAL/actions/workflows/unittests.yml)
 
 Requirements
 ============

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
         "ext-dom": "*",
         "ext-gettext": "*",
         "ext-simplexml": "*",
-        "php": "^7.3",
+        "php": "^7.3||^8.0",
         "symfony/polyfill-mbstring": "^1.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
   </coverage>
   <php>
     <ini name="display_errors" value="1"/>
+    <ini name="zend.exception_ignore_args" value="0"/>
   </php>
   <testsuites>
     <testsuite name="PHPTALtests">

--- a/src/FileSource.php
+++ b/src/FileSource.php
@@ -35,7 +35,14 @@ class FileSource implements SourceInterface
     {
         $this->path = realpath($path);
         if ($this->path === false) {
-            throw new Exception\IOException("Unable to find real path of file '$path' (in " . getcwd() . ')');
+            throw new Exception\IOException(
+                sprintf('Unable to find real path of file \'%s\' (in %s)', $path, getcwd())
+            );
+        }
+        if (is_dir($this->path)) {
+            throw new Exception\IOException(
+                sprintf('Path \'%s\' points to a directory', $this->path)
+            );
         }
     }
 

--- a/tests/FileSourceTest.php
+++ b/tests/FileSourceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PhpTal\Exception\IOException;
+use PhpTal\FileSource;
+use PHPUnit\Framework\TestCase;
+
+class FileSourceTest extends TestCase
+{
+    public function testInstantiationThrowsErrorIfPathDoesNotExist(): void
+    {
+        $path = __DIR__ . '/does/not/exist';
+
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessage(
+            sprintf('Unable to find real path of file \'%s\' (in %s)', $path, getcwd())
+        );
+
+        new FileSource($path);
+    }
+
+    public function testInstantiationThrowsErrorIfDirectory(): void
+    {
+        $dir = __DIR__;
+
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessage(
+            sprintf('Path \'%s\' points to a directory', $dir)
+        );
+
+        new FileSource($dir);
+    }
+}

--- a/tests/ReadableErrorTest.php
+++ b/tests/ReadableErrorTest.php
@@ -98,13 +98,8 @@ class ReadableErrorTest extends PhpTalTestCase
         } catch (TemplateException $e) {
             $msg = $e->getMessage();
             static::assertIsString($e->srcFile, $msg);
-
-			/**
-			 * @todo These assertions fail on certain environments (github
-			 * actions for example). The cuase is unknown
             static::assertStringContainsString($expected_file ?: $file, $e->srcFile, $msg);
             static::assertEquals($line, $e->srcLine, 'Wrong line number: ' . $msg . "\n" . $tpl->getCodePath());
-			 */
         }
     }
 }

--- a/tests/TalTestCaseRepeatTest.php
+++ b/tests/TalTestCaseRepeatTest.php
@@ -151,13 +151,12 @@ class TalTestCaseRepeatTest extends PhpTalTestCase
 
     public function testTraversableRepeat(): void
     {
-        static::markTestSkipped('this condition works with php only. maybe add comparism-operators to tal:condition?');
         $doc = new DOMDocument();
         $doc->loadXML('<a><b/><c/><d/><e/><f/><g/></a>');
 
         $tpl = $this->newPHPTAL();
         $tpl->setSource(
-            '<tal:block tal:repeat="node nodes"><tal:block tal:condition="php:repeat.node.index==4">(len=${repeat/node/length})</tal:block>${repeat/node/key}${node/tagName}</tal:block>'
+            '<tal:block tal:repeat="node nodes"><tal:block tal:condition="php:repeat.node.index==4">(len=${nodes/length})</tal:block>${repeat/node/key}${node/tagName}</tal:block>'
         );
         $tpl->nodes = $doc->getElementsByTagName('*');
 

--- a/tests/TalesRegistryTest.php
+++ b/tests/TalesRegistryTest.php
@@ -72,7 +72,7 @@ namespace Tests {
         public function testUnregisterFunction(): void
         {
             $this->expectException(UnknownModifierException::class);
-            $test_prefix = 'testprefix';
+            $test_prefix = uniqid('testprefix');
             TalesRegistry::registerPrefix($test_prefix, 'registry_test_callback3');
             TalesRegistry::unregisterPrefix($test_prefix);
             $this->newPHPTAL()->setSource('<p tal:content="' . $test_prefix . ':"/>')->execute();


### PR DESCRIPTION
Based on some work by @Slamdunk upstream (which is kinda dead), we add php8 as supported
plattform.
- Re-Enable some tests which have been disabled due some php.ini
  problmes
- Add github action badge to Readme