### PR TITLE
Remove redundant symfony/polyfill-php82 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "ext-dom": "*",
         "ext-gettext": "*",
         "ext-simplexml": "*",
-        "symfony/polyfill-mbstring": "^1.12",
-        "symfony/polyfill-php82": "^1.26"
+        "symfony/polyfill-mbstring": "^1.12"
     },
     "require-dev": {
         "ext-mbstring": "*",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php82`, but also `php: ~8.3.0 || ~8.4.0 || ~8.5.0`, so the polyfill requirement doesn't seem necessary anymore?